### PR TITLE
hplip: enable install of HP CUPS ppd files

### DIFF
--- a/hplip/Makefile
+++ b/hplip/Makefile
@@ -39,6 +39,7 @@ CONFIGURE_ARGS += \
 	--disable-pp-build \
 	--disable-doc-build \
 	--disable-foomatic-xml-install \
+	--enable-cups-ppd-install \
 	--with-cupsbackenddir=/opt/lib/cups/backend \
 	--with-cupsfilterdir=/opt/lib/cups/filter \
 	--with-icondir=/opt/var \


### PR DESCRIPTION
The default config left out nearly 800 HP ppd files, necessary for printing to HP printers.  This change fixes that omission.